### PR TITLE
master: Fix KeyError when removing object that is not referenced in ordering annotation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix KeyError when removing object that is not referenced
+  in ordering annotation
+  [vangheem]
 
 
 2.0.1 (2018-09-23)

--- a/src/plone/folder/default.py
+++ b/src/plone/folder/default.py
@@ -34,8 +34,11 @@ class DefaultOrdering(object):
         """ see interfaces.py """
         order = self._order()
         pos = self._pos()
-        idx = pos[obj_id]
-        del order[idx]
+        try:
+            idx = pos[obj_id]
+            del order[idx]
+        except KeyError:
+            pass
         # we now need to rebuild pos since the ids have shifted
         pos.clear()
         for count, obj_id in enumerate(order):

--- a/src/plone/folder/tests/test_ordersupport.py
+++ b/src/plone/folder/tests/test_ordersupport.py
@@ -344,3 +344,20 @@ class PloneOrderSupportTests(unittest.TestCase):
         self.assertEqual(self.folder.getObjectPosition('bar'), 0)
         self.assertEqual(self.folder.getObjectPosition('foo'), 1)
         self.assertEqual(self.folder.getObjectPosition('baz'), 2)
+
+    def testNotifyRemoved(self):
+        ordering = self.folder.getOrdering()
+        self.assertEqual(
+            ordering.idsInOrder(),
+            ['foo', 'bar', 'baz']
+        )
+
+        # make sure notifyRemoved with non-existent id does not throw error
+        ordering.notifyRemoved('foobar')
+
+        # normal
+        ordering.notifyRemoved('foo')
+        self.assertEqual(
+            ordering.idsInOrder(),
+            ['bar', 'baz']
+        )


### PR DESCRIPTION
\cc @plone/framework-team 