### PR TITLE
Implement a simplified and fast traverse: use it in GOPIP.

### DIFF
--- a/news/14.bugfix
+++ b/news/14.bugfix
@@ -1,0 +1,4 @@
+- Fixes slow lookup of ``documentToKeyMap`` in GopipIndex.
+  About up to 66x speedup in some cases.
+  This may add up to seconds less on large navtree renderings.
+  [jensens]


### PR DESCRIPTION
fwd port of https://github.com/plone/plone.app.folder/pull/23