### PR TITLE
optimize loop in moveObjectsByDelta

### DIFF
--- a/news/15.bugfix
+++ b/news/15.bugfix
@@ -1,0 +1,3 @@
+Micro-optimization of often called loop in moveObjectsByDelta.
+``x in y`` is up to 1000 times faster if y is a set and not a list.
+[jensens]

--- a/src/plone/folder/default.py
+++ b/src/plone/folder/default.py
@@ -81,8 +81,12 @@ class DefaultOrdering(object):
             if delta > 0:
                 subset_ids.reverse()
             idx = 0
+            # micro-optimization 1: set is 1000 time faster on contains than list
+            subset_ids_as_set = set(subset_ids)
+            # micro-optimization 2: speedup on lookup in bytecode
+            order_getitem = order.__getitem__
             for i in range(len(order)):
-                if order[i] not in subset_ids:
+                if order_getitem(i) not in subset_ids_as_set:
                     continue
                 obj_id = subset_ids[idx]
                 try:

--- a/src/plone/folder/partial.py
+++ b/src/plone/folder/partial.py
@@ -15,7 +15,7 @@ ORDER_ATTR = '_objectordering'
 
 @implementer(IExplicitOrdering)
 class PartialOrdering(object):
-    """ this implementation uses a list ot store order information on a
+    """ this implementation uses a list to store order information on a
         regular attribute of the folderish object;  explicit ordering
         is supported """
     adapts(IOrderableFolder)
@@ -96,8 +96,10 @@ class PartialOrdering(object):
             if delta > 0:
                 subset_ids.reverse()
             idx = 0
+            # micro-optimization: set is 1000 time faster on contains than list
+            subset_ids_as_set = set(subset_ids)
             for i, value in enumerate(self.order):
-                if value in subset_ids:
+                if value in subset_ids_as_set:
                     id = subset_ids[idx]
                     try:
                         self.order[i] = id


### PR DESCRIPTION
Micro-optimization of often called loop in moveObjectsByDelta.
``x in y`` is up to 1000 times faster if y is a set and not a list.