### PR TITLE
Draft: Use catalog's getpath method instead of internals

### DIFF
--- a/src/plone/folder/nogopip.py
+++ b/src/plone/folder/nogopip.py
@@ -87,11 +87,13 @@ class GopipIndex(StubIndex):
         # results themselves.  luckily this is only ever called from
         # `sortResults`, so we can get it form there.  oh, and lurker
         # says this won't work in jython, though! :)
-        rs = currentframe().f_back.f_locals["rs"]
+        caller_locals = currentframe().f_back.f_locals
+        catalog = caller_locals["self"].aq_parent
+        rs = caller_locals["rs"]
         rids = {}
         items = []
         containers = {}
-        getpath = self.catalog.paths.get
+        getpath = catalog.getpath
         root = getUtility(ISiteRoot).getPhysicalRoot()
         for rid in rs:
             path = getpath(rid)

--- a/src/plone/folder/ordered.py
+++ b/src/plone/folder/ordered.py
@@ -195,9 +195,6 @@ class OrderedBTreeFolderBase(BTreeFolder2Base):
         if old_position is None:
             return result
         self.moveObjectToPosition(new_id, old_position, suppress_events=True)
-        reindex = getattr(self._getOb(new_id), "reindexObject", None)
-        if reindex is not None:
-            reindex(idxs=["getObjPositionInParent"])
         return result
 
     # Dict interface


### PR DESCRIPTION
This is a change related to my experiment in https://github.com/plone/Products.CMFPlone/pull/3834