### PR TITLE
Fix partial ordering tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,16 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.14.0
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.12.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/codespell-project/codespell
@@ -58,7 +58,7 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.21.3"
+    rev: "0.22.0"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']

--- a/news/23.bugfix
+++ b/news/23.bugfix
@@ -1,0 +1,2 @@
+Fix partial ordering tests.
+[maurits]

--- a/src/plone/folder/tests/test_partialordering.py
+++ b/src/plone/folder/tests/test_partialordering.py
@@ -67,7 +67,11 @@ class PartialOrderingTests(unittest.TestCase):
             container, ordering = self.create()
             ids = set(container.objectIds())
             method = getattr(ordering, action)
-            if isinstance(rval, Exception):
+            if isinstance(rval, type):
+                # This means the return value is an Exception class.
+                # It is NOT an *instance* of an Exception class,
+                # so the following would not work:
+                # isinstance(rval, Exception)
                 self.assertRaises(rval, method, *args)
             else:
                 self.assertEqual(method(*args), rval)

--- a/src/plone/folder/tests/test_partialordering.py
+++ b/src/plone/folder/tests/test_partialordering.py
@@ -67,11 +67,7 @@ class PartialOrderingTests(unittest.TestCase):
             container, ordering = self.create()
             ids = set(container.objectIds())
             method = getattr(ordering, action)
-            if isinstance(rval, type):
-                # This means the return value is an Exception class.
-                # It is NOT an *instance* of an Exception class,
-                # so the following would not work:
-                # isinstance(rval, Exception)
+            if isinstance(rval, type) and issubclass(rval, Exception):
                 self.assertRaises(rval, method, *args)
             else:
                 self.assertEqual(method(*args), rval)


### PR DESCRIPTION
See https://github.com/plone/plone.folder/pull/23#issuecomment-1901343996.  Quoting from that comment:

I saw that today when adding `plone.folder` to the checkouts in 6.1.  See [Jenkins](https://jenkins.plone.org/job/plone-6.1-python-3.12/124/testReport/):

```
No object with id "n2" exists.

  File "/srv/python3.12/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/srv/python3.12/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/srv/python3.12/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/home/jenkins/workspace/plone-6.1-python-3.12/src/plone.folder/src/plone/folder/tests/test_partialordering.py", line 208, in testGetObjectPosition
    self.runTableTests(
  File "/home/jenkins/workspace/plone-6.1-python-3.12/src/plone.folder/src/plone/folder/tests/test_partialordering.py", line 73, in runTableTests
    self.assertEqual(method(*args), rval)
                     ^^^^^^^^^^^^^
  File "/home/jenkins/workspace/plone-6.1-python-3.12/src/plone.folder/src/plone/folder/partial.py", line 170, in getObjectPosition
    raise ValueError('No object with id "%s" exists.' % id)
```
